### PR TITLE
Allow the use of fields that requires pre-processing

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -40,7 +40,7 @@ def bulk_update(objs, update_fields=None, exclude_fields=None,
                         .format(when="WHEN %s THEN %s {when}")
    
                 case_clauses[column]['params'].extend(
-                    [obj.pk, field.get_db_prep_value(getattr(obj, field.attname), None)])
+                    [obj.pk, field.get_db_prep_value(getattr(obj, field.attname), connection)])
 
         if pks:
             values = ', '.join(


### PR DESCRIPTION
Using JSONField (https://github.com/bradjasper/django-jsonfield) with this great snippet raises an exception since it tries to update the database with a raw dictionary.

Django fields include a method named get_db_prep_value(self, value, connection) that prepares the field for database consumption, this pull request simply ensures we call it for every field.
