### PR TITLE
Update performance test outputs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ django-bulk-update
 
 Simple bulk update over Django ORM or with helper function.
 
-This project aims to bulk update given objects using **one query** over **Django ORM**.
+This project aims to bulk update given objects using **one query** over
+**Django ORM**.
 
 Installation
 ==================================
@@ -15,81 +16,96 @@ Usage
 ==================================
 With manager:
 
-    from bulk_update.manager import BulkUpdateManager
+```python
+from bulk_update.manager import BulkUpdateManager
 
-    class Person(models.Model):
-        ...
-        objects = BulkUpdateManager()
-        
-    random_names = ['Walter', 'The Dude', 'Donny', 'Jesus']
-    people = Person.objects.all()
-    for person in people:
-      r = random.randrange(4)
-      person.name = random_names[r]
+class Person(models.Model):
+    ...
+    objects = BulkUpdateManager()
 
-    Person.objects.bulk_update(people, update_fields=['name'])  # updates only name column
-    Person.objects.bulk_update(people, exclude_fields=['username'])  # updates all columns except username
-    Person.objects.bulk_update(people)  # updates all columns
-    Person.objects.bulk_update(people, batch_size=50000)  # updates all columns by 50000 sized chunks
+random_names = ['Walter', 'The Dude', 'Donny', 'Jesus']
+people = Person.objects.all()
+for person in people:
+  r = random.randrange(4)
+  person.name = random_names[r]
+
+Person.objects.bulk_update(people, update_fields=['name'])  # updates only name column
+Person.objects.bulk_update(people, exclude_fields=['username'])  # updates all columns except username
+Person.objects.bulk_update(people)  # updates all columns
+Person.objects.bulk_update(people, batch_size=50000)  # updates all columns by 50000 sized chunks
+```
 
 
 With helper:
 
-    from bulk_update.helper import bulk_update
+```python
+from bulk_update.helper import bulk_update
 
-    random_names = ['Walter', 'The Dude', 'Donny', 'Jesus']
-    people = Person.objects.all()
-    for person in people:
-      r = random.randrange(4)
-      person.name = random_names[r]
+random_names = ['Walter', 'The Dude', 'Donny', 'Jesus']
+people = Person.objects.all()
+for person in people:
+  r = random.randrange(4)
+  person.name = random_names[r]
 
-    bulk_update(people, update_fields=['name'])  # updates only name column
-    bulk_update(people, exclude_fields=['username'])  # updates all columns except username 
-    bulk_update(people, using='someotherdb')  # updates all columns using the given db
-    bulk_update(people)  # updates all columns using the default db
-    bulk_update(people, batch_size=50000)  # updates all columns by 50000 sized chunks using the default db
+bulk_update(people, update_fields=['name'])  # updates only name column
+bulk_update(people, exclude_fields=['username'])  # updates all columns except username
+bulk_update(people, using='someotherdb')  # updates all columns using the given db
+bulk_update(people)  # updates all columns using the default db
+bulk_update(people, batch_size=50000)  # updates all columns by 50000 sized chunks using the default db
+```
 
 Performance Tests:
 ==================================
 
-    setup='''
-    from test.person.models import Person
-    ids=list(Person.objects.values_list('id', flat=True)[:1000])
-    from django.db.models import F
-    people=Person.objects.filter(id__in=ids)
-    dj_update = lambda: people.update(name=F('name'), surname=F('surname'))
-    '''
-    >> import timeit
-    >> print min(timeit.Timer('dj_update()', setup=setup).repeat(7, 100))
-    >> 1.43143701553
-    
-    setup='''
-    from bulk_update import helper
-    from test.person.models import Person
-    ids=list(Person.objects.values_list('id', flat=True)[:1000])
-    people=Person.objects.filter(id__in=ids)
-    bu_update = lambda: helper.bulk_update(people, update_fields=['name', 'surname'])
-    '''
-    
-    >> import timeit
-    >> print min(timeit.Timer('bu_update()', setup=setup).repeat(7, 100))
-    >> 15.0784111023
-    
-    setup='''
-    from test.person.models import Person
-    from django.db.models import F
-    ids=list(Person.objects.values_list('id', flat=True)[:1000])
-    people=Person.objects.filter(id__in=ids)
-    def dmmy_update():
-        for p in people:
-            p.name = F('name')
-            p.surname = F('surname')
-            p.save(update_fields=['name', 'surname'])
-    '''
-    
-    >> import timeit
-    >> print min(timeit.Timer('dmmy_update()', setup=setup).repeat(7, 100))
-    >> 201.827591181
+```python
+# Note: SQlite is unable to run the `timeit` tests
+# due to the max number of sql variables
+In [1]: import os
+In [2]: import timeit
+In [3]: import django
+
+In [4]: os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
+In [5]: django.setup()
+
+In [6]: from tests.fixtures import create_fixtures
+
+In [7]: django.db.connection.creation.create_test_db()
+In [8]: create_fixtures(1000)
+
+In [9]: setup='''
+  ....: from tests.models import Person
+  ....: ids=list(Person.objects.values_list('id', flat=True)[:1000])
+  ....: from django.db.models import F
+  ....: people=Person.objects.filter(id__in=ids)
+  ....: dj_update = lambda: people.update(name=F('name'), email=F('email'))
+  ....: '''
+In [10]: print "Django update performance:", min(timeit.Timer('dj_update()', setup=setup).repeat(7, 100))
+Django update performance: 1.1035900116
+
+In [11]: setup='''
+  ....: from bulk_update import helper
+  ....: from tests.models import Person
+  ....: ids=list(Person.objects.values_list('id', flat=True)[:1000])
+  ....: people=Person.objects.filter(id__in=ids)
+  ....: bu_update = lambda: helper.bulk_update(people, update_fields=['name', 'email'])
+  ....: '''
+In [12]: print "Bulk update performance:", min(timeit.Timer('bu_update()', setup=setup).repeat(7, 100))
+Bulk update performance: 11.0196619034
+
+In [13]: setup='''
+  ....: from tests.models import Person
+  ....: from django.db.models import F
+  ....: ids=list(Person.objects.values_list('id', flat=True)[:1000])
+  ....: people=Person.objects.filter(id__in=ids)
+  ....: def dmmy_update():
+  ....:     for p in people:
+  ....:         p.name = F('name')
+  ....:         p.email = F('email')
+  ....:         p.save(update_fields=['name', 'email'])
+  ....: '''
+In [14]: print "Naive update performance", min(timeit.Timer('dmmy_update()', setup=setup).repeat(7, 100))
+Naive update performance 340.86224699
+```
 
 Requirements
 ==================================

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ def dmmy_update():
 
 In [12]: dmmy_perf = min(timeit.Timer('dmmy_update()', setup=setup).repeat(7, 100))
 In [13]: print 'Bulk update performance: %.2f. Dummy update performance: %.2f. Speedup: %.2f.' % (bu_perf, dmmy_perf, dmmy_perf / bu_perf)
-
+Bulk update performance: 7.05. Dummy update performance: 373.12. Speedup: 52.90.
 ```
 
 Requirements

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 import itertools
 
 from django.utils import timezone
+from six.moves import xrange
 
 from .models import Person
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,101 @@
+from datetime import date, time, timedelta
+from decimal import Decimal
+import itertools
+
+from django.utils import timezone
+
+from .models import Person
+
+def get_fixtures(n=None):
+    """
+      Returns `n` dictionaries of `Person` objects.
+      If `n` is not specified it defaults to 6.
+    """
+    _now = timezone.now().replace(microsecond=0)  # mysql doesn't do microseconds. # NOQA
+    _date = date(2015, 3, 28)
+    _time = time(13, 0)
+    FIXTURES = [
+        {
+            'big_age': 59999999999999999, 'comma_separated_age': '1,2,3',
+            'age': -99, 'positive_age': 9999, 'positive_small_age': 299,
+            'small_age': -299, 'certified': False, 'null_certified': None,
+            'name': 'Mike', 'email': 'miketakeahike@mailinator.com',
+            'file_path': '/Users/user/fixtures.json', 'slug': 'mike',
+            'text': 'here is a dummy text',
+            'url': 'https://docs.djangoproject.com',
+            'height': Decimal('1.81'), 'date_time': _now,
+            'date': _date, 'time': _time, 'float_height': 0.3,
+            'remote_addr': '192.0.2.30', 'my_file': 'dummy.txt',
+            'image': 'kitten.jpg', 'data': {'name': 'Mike', 'age': -99},
+        },
+        {
+            'big_age': 245999992349999, 'comma_separated_age': '6,2,9',
+            'age': 25, 'positive_age': 49999, 'positive_small_age': 315,
+            'small_age': 5409, 'certified': False, 'null_certified': True,
+            'name': 'Pete', 'email': 'petekweetookniet@mailinator.com',
+            'file_path': 'users.json', 'slug': 'pete', 'text': 'dummy',
+            'url': 'https://google.com', 'height': Decimal('1.93'),
+            'date_time': _now, 'date': _date, 'time': _time,
+            'float_height': 0.5, 'remote_addr': '127.0.0.1',
+            'my_file': 'fixtures.json',
+            'data': [{'name': 'Pete'}, {'name': 'Mike'}],
+        },
+        {
+            'big_age': 9929992349999, 'comma_separated_age': '6,2,9,10,5',
+            'age': 29, 'positive_age': 412399, 'positive_small_age': 23315,
+            'small_age': -5409, 'certified': False, 'null_certified': True,
+            'name': 'Ash', 'email': 'rashash@mailinator.com',
+            'file_path': '/Downloads/kitten.jpg', 'slug': 'ash',
+            'text': 'bla bla bla', 'url': 'news.ycombinator.com',
+            'height': Decimal('1.78'), 'date_time': _now,
+            'date': _date, 'time': _time,
+            'float_height': 0.8, 'my_file': 'dummy.png',
+            'data': {'text': 'bla bla bla', 'names': ['Mike', 'Pete']},
+        },
+        {
+            'big_age': 9992349234, 'comma_separated_age': '12,29,10,5',
+            'age': -29, 'positive_age': 4199, 'positive_small_age': 115,
+            'small_age': 909, 'certified': True, 'null_certified': False,
+            'name': 'Mary', 'email': 'marykrismas@mailinator.com',
+            'file_path': 'dummy.png', 'slug': 'mary',
+            'text': 'bla bla bla bla bla', 'url': 'news.ycombinator.com',
+            'height': Decimal('1.65'), 'date_time': _now,
+            'date': _date, 'time': _time, 'float_height': 0,
+            'remote_addr': '2a02:42fe::4',
+            'data': {'names': {'name': 'Mary'}},
+        },
+        {
+            'big_age': 999234, 'comma_separated_age': '12,1,30,50',
+            'age': 1, 'positive_age': 99199, 'positive_small_age': 5,
+            'small_age': -909, 'certified': False, 'null_certified': False,
+            'name': 'Sandra', 'email': 'sandrasalamandr@mailinator.com',
+            'file_path': '/home/dummy.png', 'slug': 'sandra',
+            'text': 'this is a dummy text', 'url': 'google.com',
+            'height': Decimal('1.59'), 'date_time': _now,
+            'date': _date, 'time': _time, 'float_height': 2 ** 2,
+            'image': 'dummy.jpeg', 'data': {},
+        },
+        {
+            'big_age': 9999999999, 'comma_separated_age': '1,100,3,5',
+            'age': 35, 'positive_age': 1111, 'positive_small_age': 500,
+            'small_age': 110, 'certified': True, 'null_certified': None,
+            'name': 'Crystal', 'email': 'crystalpalace@mailinator.com',
+            'file_path': '/home/dummy.txt', 'slug': 'crystal',
+            'text': 'dummy text', 'url': 'docs.djangoproject.com',
+            'height': Decimal('1.71'), 'date_time': _now,
+            'date': _date, 'time': _time, 'float_height': 2 ** 10,
+            'image': 'dummy.png', 'data': [],
+        },
+    ]
+    n = n or len(FIXTURES)
+    fixtures = itertools.cycle(FIXTURES)
+    for _ in xrange(n):
+        yield fixtures.next()
+
+
+def create_fixtures(n=None):
+    """
+      Wrapper for Person.bulk_create which creates `n` fixtures
+    """
+    Person.objects.bulk_create(Person(**person)
+                               for person in get_fixtures(n))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,7 +15,7 @@ def get_fixtures(n=None):
     _now = timezone.now().replace(microsecond=0)  # mysql doesn't do microseconds. # NOQA
     _date = date(2015, 3, 28)
     _time = time(13, 0)
-    FIXTURES = [
+    fixtures = [
         {
             'big_age': 59999999999999999, 'comma_separated_age': '1,2,3',
             'age': -99, 'positive_age': 9999, 'positive_small_age': 299,
@@ -88,8 +88,8 @@ def get_fixtures(n=None):
             'image': 'dummy.png', 'data': [],
         },
     ]
-    n = n or len(FIXTURES)
-    fixtures = itertools.cycle(FIXTURES)
+    n = n or len(fixtures)
+    fixtures = itertools.cycle(fixtures)
     for _ in xrange(n):
         yield next(fixtures)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -91,7 +91,7 @@ def get_fixtures(n=None):
     n = n or len(FIXTURES)
     fixtures = itertools.cycle(FIXTURES)
     for _ in xrange(n):
-        yield fixtures.next()
+        yield next(fixtures)
 
 
 def create_fixtures(n=None):

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -1,3 +1,4 @@
 dj-database-url
 Pillow==2.7.0
 jsonfield==1.0.3
+six==1.9.0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,7 +10,7 @@ db_url = os.environ.get("DATABASE_URL", "sqlite://localhost/:memory:")
 DB = dj_database_url.parse(db_url)
 
 DATABASES = {
-	'default': DB,
+    'default': DB,
 }
 
 INSTALLED_APPS = ('bulk_update', 'tests',)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,91 +1,21 @@
-from datetime import timedelta, date, time
+from datetime import date, time, timedelta
 from decimal import Decimal
 import random
 
-from django.utils import timezone
 from django.test import TestCase
+from django.utils import timezone
 
 from .models import Person
+from .fixtures import create_fixtures
 
 
 class BulkUpdateTests(TestCase):
+
     def setUp(self):
         self.now = timezone.now().replace(microsecond=0)  # mysql doesn't do microseconds. # NOQA
         self.date = date(2015, 3, 28)
         self.time = time(13, 0)
-        Person.objects.bulk_create(Person(**person) for person in [
-            {
-                'big_age': 59999999999999999, 'comma_separated_age': '1,2,3',
-                'age': -99, 'positive_age': 9999, 'positive_small_age': 299,
-                'small_age': -299, 'certified': False, 'null_certified': None,
-                'name': 'Mike', 'email': 'miketakeahike@mailinator.com',
-                'file_path': '/Users/user/fixtures.json', 'slug': 'mike',
-                'text': 'here is a dummy text',
-                'url': 'https://docs.djangoproject.com',
-                'height': Decimal('1.81'), 'date_time': self.now,
-                'date': self.date, 'time': self.time, 'float_height': 0.3,
-                'remote_addr': '192.0.2.30', 'my_file': 'dummy.txt',
-                'image': 'kitten.jpg', 'data': {'name': 'Mike', 'age': -99},
-            },
-            {
-                'big_age': 245999992349999, 'comma_separated_age': '6,2,9',
-                'age': 25, 'positive_age': 49999, 'positive_small_age': 315,
-                'small_age': 5409, 'certified': False, 'null_certified': True,
-                'name': 'Pete', 'email': 'petekweetookniet@mailinator.com',
-                'file_path': 'users.json', 'slug': 'pete', 'text': 'dummy',
-                'url': 'https://google.com', 'height': Decimal('1.93'),
-                'date_time': self.now, 'date': self.date, 'time': self.time,
-                'float_height': 0.5, 'remote_addr': '127.0.0.1',
-                'my_file': 'fixtures.json',
-                'data': [{'name': 'Pete'}, {'name': 'Mike'}],
-            },
-            {
-                'big_age': 9929992349999, 'comma_separated_age': '6,2,9,10,5',
-                'age': 29, 'positive_age': 412399, 'positive_small_age': 23315,
-                'small_age': -5409, 'certified': False, 'null_certified': True,
-                'name': 'Ash', 'email': 'rashash@mailinator.com',
-                'file_path': '/Downloads/kitten.jpg', 'slug': 'ash',
-                'text': 'bla bla bla', 'url': 'news.ycombinator.com',
-                'height': Decimal('1.78'), 'date_time': self.now,
-                'date': self.date, 'time': self.time,
-                'float_height': 0.8, 'my_file': 'dummy.png',
-                'data': {'text': 'bla bla bla', 'names': ['Mike', 'Pete']},
-            },
-            {
-                'big_age': 9992349234, 'comma_separated_age': '12,29,10,5',
-                'age': -29, 'positive_age': 4199, 'positive_small_age': 115,
-                'small_age': 909, 'certified': True, 'null_certified': False,
-                'name': 'Mary', 'email': 'marykrismas@mailinator.com',
-                'file_path': 'dummy.png', 'slug': 'mary',
-                'text': 'bla bla bla bla bla', 'url': 'news.ycombinator.com',
-                'height': Decimal('1.65'), 'date_time': self.now,
-                'date': self.date, 'time': self.time, 'float_height': 0,
-                'remote_addr': '2a02:42fe::4',
-                'data': {'names': {'name': 'Mary'}},
-            },
-            {
-                'big_age': 999234, 'comma_separated_age': '12,1,30,50',
-                'age': 1, 'positive_age': 99199, 'positive_small_age': 5,
-                'small_age': -909, 'certified': False, 'null_certified': False,
-                'name': 'Sandra', 'email': 'sandrasalamandr@mailinator.com',
-                'file_path': '/home/dummy.png', 'slug': 'sandra',
-                'text': 'this is a dummy text', 'url': 'google.com',
-                'height': Decimal('1.59'), 'date_time': self.now,
-                'date': self.date, 'time': self.time, 'float_height': 2 ** 2,
-                'image': 'dummy.jpeg', 'data': {},
-            },
-            {
-                'big_age': 9999999999, 'comma_separated_age': '1,100,3,5',
-                'age': 35, 'positive_age': 1111, 'positive_small_age': 500,
-                'small_age': 110, 'certified': True, 'null_certified': None,
-                'name': 'Crystal', 'email': 'crystalpalace@mailinator.com',
-                'file_path': '/home/dummy.txt', 'slug': 'crystal',
-                'text': 'dummy text', 'url': 'docs.djangoproject.com',
-                'height': Decimal('1.71'), 'date_time': self.now,
-                'date': self.date, 'time': self.time, 'float_height': 2 ** 10,
-                'image': 'dummy.png', 'data': [],
-            },
-        ])
+        create_fixtures()
 
     def test_big_integer_field(self):
         people = Person.objects.order_by('pk').all()


### PR DESCRIPTION
@aykut here are the updated performance numbers after merging #13 / #14 . I tested it on a pretty weak MySql instance so this might account for the performance drop in the `dmmy_update` method (since there are so many more db connections instantiated).

Feel free to test against your own instance to get the numbers but it does seem the `.count()` method helped a bit. We can also bump up the number of items updated to stress the system a bit more (maybe 5k?). Also, a more compelling test case might be to not show the `dj_update` method at all but rather just how `bulk_update` performs against `dmmy_update` when updating field with arbitrary values since `dj_update` won't apply here. Thoughts?