### PR TITLE
add setup.py command to create git tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Contributors
 - [c-nichols](https://github.com/c-nichols)
 - [towr](https://github.com/towr)
 - [joshblum](https://github.com/joshblum)
+- [luzfcb](https://github.com/luzfcb)
 
 TODO
 ==================================

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from setuptools import setup, find_packages
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
@@ -6,9 +7,21 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
+version = "1.1.3"
+
+if sys.argv[-1] == 'publish':
+    os.system('python setup.py sdist upload')
+    os.system('python setup.py bdist_wheel upload')
+    sys.exit()
+
+if sys.argv[-1] == 'tag':
+    os.system("git tag -a %s -m 'version %s'" % (version, version))
+    os.system("git push --tags")
+    sys.exit()
+
 setup(
     name='django-bulk-update',
-    version='1.1.3',
+    version=version,
     packages=find_packages(),
     include_package_data=True,
     description='Bulk update using one query over Django ORM.',
@@ -19,6 +32,7 @@ setup(
     install_requires=[
         'django>=1.2',
     ],
+    zip_safe=False,
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
and easy publish on pypi:

first generate packages and sent to pypi:
`python setup.py publish`

after, create a gittag and push to github:
`python setup.py tag`

[bdist_wheel](https://github.com/luzfcb/django-bulk-update/blob/master/setup.py#L14) require wheels package was installed. You probably should not worry about it because pip> = 7.0 install the wheels package by default

The `zip_safe=False` flag can be used to force or prevent zip Archive creation. In general you probably don’t want your packages to be installed as zip files because some tools do not support them and they make debugging a lot harder.
