### PR TITLE
Now we can specify which field to use in WHERE IN

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -47,6 +47,9 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
         # TODO: account for iterables
         meta = objs[0]._meta
 
+    if pk_field == 'pk'
+        pk_field = meta.pk.name
+
     exclude_fields = exclude_fields or []
     update_fields = update_fields or meta.get_all_field_names()
     fields = [

--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -102,7 +102,7 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
                 except KeyError:
                     case_clause = {
                         'sql': case_clause_template.format(
-                            column=column, pkcolumn=getattr(meta, pk_field).column),
+                            column=column, pkcolumn=meta.get_field(pk_field).column),
                         'params': [],
                         'type': _get_db_type(field, connection=connection),
                     }
@@ -128,7 +128,7 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
 
             del case_clauses  # ... memory
 
-            pkcolumn = getattr(meta, pk_field).column
+            pkcolumn = meta.get_field(pk_field).column
             dbtable = '{0}{1}{0}'.format(quote_mark, meta.db_table)
             # Storytime: apparently (at least for mysql and sqlite), if a
             # non-simple parameter is added (e.g. a tuple), it is

--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -47,7 +47,7 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
         # TODO: account for iterables
         meta = objs[0]._meta
 
-    if pk_field == 'pk'
+    if pk_field == 'pk':
         pk_field = meta.pk.name
 
     exclude_fields = exclude_fields or []


### PR DESCRIPTION
Now we can specify which field to use in WHERE IN. So we can update
models by custom field.

Use case:

User has some external resources and these resources are loaded into django database more than once. But related data like analytics should be stored once as it is ONE resource, which has TWO instances in our DB - like m2m.

So, we should be able to update all resources at once by one query. For example, we have 1 resource with EXT_RES1, but we have 2 instances in our DB: OUR_RES1(EXT_RES_ID=1), OUR_RES2(EXT_RES_ID=1).

So we should be able to throw a query like UPDATE ... WHERE EXT_RES_ID in (1 ... ).

With this commit we can specify which field to use instead of PK, so we can use EXT_RES_ID and it will do the trick.