### PR TITLE
Use uppercase SQL for Oracle

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -142,6 +142,9 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
                 .format(
                     dbtable=dbtable, values=values, pkcolumn=pkcolumn,
                     in_clause_sql=in_clause_sql))
+            if connection.vendor == 'oracle':
+                # Oracle likes all SQL in uppercase
+                sql = sql.upper().replace('%S', '%s')
             del values, pks
 
             connection.cursor().execute(sql, parameters)

--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -4,6 +4,7 @@ Main module with the bulk_update function.
 """
 
 import itertools
+from collections import Iterator
 
 from django.db import connections, models
 from django.db.models.query import QuerySet
@@ -39,13 +40,19 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
     # if we have a QuerySet, avoid loading objects into memory
     if isinstance(objs, QuerySet):
         batch_size = batch_size or objs.count()
+    elif isinstance(objs, Iterator) and batch_size is None:
+        raise ValueError, 'Must supply a batch_size when using an iterator'
     else:
         batch_size = batch_size or len(objs)
 
     connection = connections[using]
     if meta is None:
-        # TODO: account for iterables
-        meta = objs[0]._meta
+        if isinstance(objs, Iterator):
+            first_object = iter(objs).next()
+            objs = itertools.chain(iter([first_object]), objs)
+            meta = first_object._meta
+        else:
+            meta = objs[0]._meta
 
     exclude_fields = exclude_fields or []
     update_fields = update_fields or meta.get_all_field_names()

--- a/bulk_update/manager.py
+++ b/bulk_update/manager.py
@@ -3,6 +3,8 @@ from .helper import bulk_update
 
 
 class BulkUpdateManager(models.Manager):
-    def bulk_update(self, objs, update_fields=None, exclude_fields=None):
+    def bulk_update(self, objs, update_fields=None, exclude_fields=None,
+            batch_size=None):
         bulk_update(objs, update_fields=update_fields,
-                    exclude_fields=exclude_fields, using=self.db)
+                    exclude_fields=exclude_fields, using=self.db,
+                    batch_size=batch_size)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -201,3 +201,16 @@ class BulkUpdateTests(TestCase):
         people = Person.objects.order_by('pk').all()
         for idx, person in enumerate(people):
             self.assertEqual(person.big_age, idx + 27)
+
+    def test_object_iter(self):
+        """
+          Pass in an iterator instead of a queryset for bulk updating
+        """
+        people = Person.objects.order_by('pk').all()
+        for idx, person in enumerate(people):
+            person.big_age = idx + 27
+        Person.objects.bulk_update(iter(people), batch_size=people.count())
+
+        people = Person.objects.order_by('pk').all()
+        for idx, person in enumerate(people):
+            self.assertEqual(person.big_age, idx + 27)


### PR DESCRIPTION
Hi there, I tried bulk_update() on an Oracle system and found the quickest way to get everything to work was changing all SQL to uppercase.

As you can see from the diff, there should be zero impact in case of another database, but for the record: this change was tested against Postgres 9.2, sqlite3 and of course Oracle XE 11g.

Cheers,
Vincent