### PR TITLE
Updated helper.py to enable standalone script execution

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -7,8 +7,18 @@ import itertools
 
 from django.db import connections, models
 from django.db.models.query import QuerySet
-
-
+"""adding the following to allow Bulk_update to be ran with scripts that are standalone 
+(aka not being triggered by webserver or django-admin.py)
+See: https://docs.djangoproject.com/en/1.8/topics/settings/#calling-django-setup-is-required-for-standalone-django-usage
+"""
+import django
+from django.utils.version import get_version
+## need Version check - if Django version >= 1.8 then we need the following code due to 1.8 changes.
+if django.VERSION[1] > 6:
+    #call django.setup() to properly assign models. Prevents the 'Models are not loaded' error
+    django.setup()
+    
+    
 def _get_db_type(field, connection):
     if isinstance(field, (models.PositiveSmallIntegerField,
                           models.PositiveIntegerField)):


### PR DESCRIPTION
Updated helper.py to enable standalone script execution where script is not being triggered by django-admin.py or the webserver. See https://docs.djangoproject.com/en/1.8/topics/settings/#calling-django-setup-is-required-for-standalone-django-usage for details. Only works for Django 1.7+