### PR TITLE
Fix bulk_update when there is no record to update. Closes #35

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -38,9 +38,12 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
 
     # if we have a QuerySet, avoid loading objects into memory
     if isinstance(objs, QuerySet):
-        batch_size = batch_size or objs.count()
+        nb_objects = objs.count()
     else:
-        batch_size = batch_size or len(objs)
+        nb_objects = len(objs)
+    if nb_objects == 0:
+        return
+    batch_size = batch_size or nb_objects
 
     connection = connections[using]
     if meta is None:

--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -38,12 +38,13 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
 
     # if we have a QuerySet, avoid loading objects into memory
     if isinstance(objs, QuerySet):
-        nb_objects = objs.count()
+        if not objs.exists():
+            return
+        batch_size = batch_size or objs.count()
     else:
-        nb_objects = len(objs)
-    if nb_objects == 0:
-        return
-    batch_size = batch_size or nb_objects
+        if not objs:
+            return
+        batch_size = batch_size or len(objs)
 
     connection = connections[using]
     if meta is None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -201,3 +201,16 @@ class BulkUpdateTests(TestCase):
         people = Person.objects.order_by('pk').all()
         for idx, person in enumerate(people):
             self.assertEqual(person.big_age, idx + 27)
+
+    def test_empty_list(self):
+        """
+        Update no elements, passed as a list
+        """
+        Person.objects.bulk_update([])
+
+    def test_empty_queryset(self):
+        """
+        Update no elements, passed as a queryset
+        """
+        Person.objects.bulk_update(Person.objects.filter(name="Aceldotanrilsteucsebces ECSbd (funny name, isn't it?)"))
+


### PR DESCRIPTION
As `bulk_update` already computes the number of elements to update, we just need to check that this number is positive before the actual update.