### PR TITLE
Fixing ForeignKey fields update on Django 1.6

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -55,7 +55,7 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
         pk_field = meta.pk.name
 
     exclude_fields = exclude_fields or []
-    update_fields = update_fields or meta.get_all_field_names()
+    update_fields = update_fields or [f.attname for f in meta.fields]
     fields = [
         f for f in meta.fields
         if ((not isinstance(f, models.AutoField))

--- a/tests/models.py
+++ b/tests/models.py
@@ -5,10 +5,15 @@ from jsonfield import JSONField
 from bulk_update.manager import BulkUpdateManager
 
 
+class Role(models.Model):
+    code = models.IntegerField()
+
+
 class Person(models.Model):
     """
         test model
     """
+    role = models.ForeignKey(Role, null=True)
     big_age = models.BigIntegerField()
     comma_separated_age = models.CommaSeparatedIntegerField(max_length=255)
     age = models.IntegerField()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,7 +5,7 @@ import random
 from django.test import TestCase
 from django.utils import timezone
 
-from .models import Person
+from .models import Person, Role
 from .fixtures import create_fixtures
 
 
@@ -173,6 +173,21 @@ class BulkUpdateTests(TestCase):
         for person1, person2 in zip(people, people2):
             self.assertEqual(person1.age, person2.age)
             self.assertNotEqual(person1.height, person2.height)
+
+    def test_update_foreign_key_fields(self):
+        roles = [Role.objects.create(code=1), Role.objects.create(code=2)]
+        people = Person.objects.order_by('pk').all()
+        for idx, person in enumerate(people):
+            person.age += 1
+            person.height += Decimal('0.01')
+            person.role = roles[0] if idx % 2 == 0 else roles[1]
+        Person.objects.bulk_update(people)
+
+        people2 = Person.objects.order_by('pk').all()
+        for person1, person2 in zip(people, people2):
+            self.assertEqual(person1.role.code, person2.role.code)
+            self.assertEqual(person1.age, person2.age)
+            self.assertEqual(person1.height, person2.height)
 
     def test_exclude_fields(self):
         """


### PR DESCRIPTION
In Django 1.6, `_meta.get_all_field_names` does not return `ForeignKey` fields
including `_id` suffix, which makes the current version skip updates