### PR TITLE
Return number of updated items as in django orm update

### DIFF
--- a/bulk_update/helper.py
+++ b/bulk_update/helper.py
@@ -106,7 +106,8 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
                 except KeyError:
                     case_clause = {
                         'sql': case_clause_template.format(
-                            column=column, pkcolumn=meta.get_field(pk_field).column),
+                            column=column,
+                            pkcolumn=meta.get_field(pk_field).column),
                         'params': [],
                         'type': _get_db_type(field, connection=connection),
                     }
@@ -149,6 +150,8 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
                 .format(
                     dbtable=dbtable, values=values, pkcolumn=pkcolumn,
                     in_clause_sql=in_clause_sql))
+            lenpks = len(pks)
             del values, pks
 
             connection.cursor().execute(sql, parameters)
+            return lenpks

--- a/bulk_update/manager.py
+++ b/bulk_update/manager.py
@@ -4,5 +4,6 @@ from .helper import bulk_update
 
 class BulkUpdateManager(models.Manager):
     def bulk_update(self, objs, update_fields=None, exclude_fields=None):
-        bulk_update(objs, update_fields=update_fields,
-                    exclude_fields=exclude_fields, using=self.db)
+        return bulk_update(
+            objs, update_fields=update_fields,
+            exclude_fields=exclude_fields, using=self.db)


### PR DESCRIPTION
```update``` method in django-orm returns the number of updated items. I suppose django-bulk-update should also return it.