### PR TITLE
Make bulk_update work with postgresql's ArrayField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 
+*~
+
 # C extensions
 *.so
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 dj_database_url==0.4.2
 jsonfield==2.0.1
 pillow==4.1.1
+psycopg2==2.7.3
 six==1.10.0

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from jsonfield import JSONField
 from uuid import uuid4
@@ -61,5 +62,12 @@ class Company(models.Model):
 class PersonUUID(models.Model):
     uuid = models.UUIDField(primary_key=True, default=uuid4)
     age = models.IntegerField()
+
+    objects = BulkUpdateManager()
+
+
+class Brand(models.Model):
+    name = models.CharField(max_length=128, unique=True, db_index=True)
+    codes = ArrayField(models.CharField(max_length=64), default=['code_1'])
 
     objects = BulkUpdateManager()

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -1,4 +1,5 @@
 dj_database_url==0.4.2
 jsonfield==2.0.1
 pillow==4.1.1
+psycopg2==2.7.3
 six==1.10.0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,7 +10,16 @@ db_url = os.environ.get("DATABASE_URL", "sqlite://localhost/:memory:")
 DB = dj_database_url.parse(db_url)
 
 DATABASES = {
-    'default': DB,
+    # 'default': DB,
+
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'default',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    }
 }
 
 INSTALLED_APPS = ('django_bulk_update', 'tests',)


### PR DESCRIPTION
Fixes #60 issue.

The problem was that some django db functions like: CONCAT, UPPER, CAST (https://docs.djangoproject.com/en/1.11/ref/models/database-functions/) have a list of arguments, while ArrayField has only one argument which is a list.

In order to distinguish between these two cases, we cast the **list of arguments** to **tuple of arguments**.