### PR TITLE
added pk_field param as a pass through to bulk update on query set

### DIFF
--- a/django_bulk_update/query.py
+++ b/django_bulk_update/query.py
@@ -5,7 +5,7 @@ from .helper import bulk_update
 class BulkUpdateQuerySet(models.QuerySet):
 
     def bulk_update(self, objs, update_fields=None,
-                    exclude_fields=None, batch_size=None):
+                    exclude_fields=None, batch_size=None, pk_field='pk'):
 
         self._for_write = True
         using = self.db
@@ -13,4 +13,4 @@ class BulkUpdateQuerySet(models.QuerySet):
         return bulk_update(
             objs, update_fields=update_fields,
             exclude_fields=exclude_fields, using=using,
-            batch_size=batch_size)
+            batch_size=batch_size, pk_field=pk_field)


### PR DESCRIPTION
The `pk_field` was not on the function signature for the `BulkUpdateQuerySet`, so I was unable to actually use it when using the `BulkUpdateManager` on a `models.Model` class. This PR enables this functionality.

It might make sense to add `**kwargs` to this proxied function to be passed into the proper `bulk_update` function to avoid misses like this in the future; however, I figured I'd leave that decision up to the maintainers in another PR.