### PR TITLE
Ordering

### DIFF
--- a/django_bulk_update/helper.py
+++ b/django_bulk_update/helper.py
@@ -207,7 +207,8 @@ def bulk_update(objs, meta=None, update_fields=None, exclude_fields=None,
         )
 
         if ordered:
-            columns = ', '.join(f'"{field.column}"' for field in parameters.keys())
+            columns = ', '.join('"{column}"'.format(column=field.column)
+                                for field in parameters.keys())
             parameters = list(pks) + flatten(parameters.values(), types=list)
 
             sql = '''with cte as


### PR DESCRIPTION
There are cases when row-level deadlocks occur on simultaneous update, celery task & Django view for instance.
If update order is preserved (order by pk) there are no more deadlocks.
Implemented via CTE.
Added "ordered=False"  for backward compatibility & keep overhead away if ordering not needed.